### PR TITLE
Add ecommerce-module-core dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
     "description": "Magento 2 Module Mundipagg",
     "require": {
         "php": "~5.6.0|~7.0.0|~7.1.0",
-        "mundipagg/mundiapi": "^3.0"
+        "mundipagg/mundiapi": "^3.0",
+        "mundipagg/ecommerce-module-core": "dev-master"
     },
     "require-dev": {
         "phpunit/phpunit": "4.1.0",
@@ -44,5 +45,11 @@
     },
     "config":{
         "secure-http":false
-    }
+    },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/mundipagg/ecommerce-module-core.git"
+        }
+    ]
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/MOD-524
| **What?**         | Add ecommerce-module-core dependency.
| **Why?**          | To separate module core from module application layer.
| **How?**          | Making module depends on module core.