### PR TITLE
Fix compatibility with legacy code

### DIFF
--- a/Concrete/Magento2PlatformOrderDecorator.php
+++ b/Concrete/Magento2PlatformOrderDecorator.php
@@ -79,7 +79,11 @@ class Magento2PlatformOrderDecorator extends AbstractPlatformOrderDecorator
 
     protected function addMPHistoryComment($message)
     {
-        $this->platformOrder->addCommentToStatusHistory($message);
+        $historyMethod = 'addCommentToStatusHistory';
+        if (!method_exists($this->platformOrder, $historyMethod)) {
+            $historyMethod = 'addStatusHistoryComment';
+        }
+        $this->platformOrder->$historyMethod($message);
     }
 
     public function setIsCustomerNotified()


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **What?**         | Fix compatibility with legacy code.
| **Why?**          | Legacy versions of Magento does not have the method 'addCommentToStatusHistory'.
| **How?**          | Added a method selector when trying to add history comment.