### PR TITLE
Set order as processing when API's response is paid.

### DIFF
--- a/Gateway/Transaction/CreditCard/ResourceGateway/Create/Response/GeneralHandler.php
+++ b/Gateway/Transaction/CreditCard/ResourceGateway/Create/Response/GeneralHandler.php
@@ -124,6 +124,10 @@ class GeneralHandler extends AbstractHandler implements HandlerInterface
             $stateMagento->setState('pending_payment')->setStatus('pending_payment');
         }
 
+        if ($capture && $apiResponseStatus == 'paid') {
+            $stateMagento->setState('processing')->setStatus('processing');
+        }
+
         if ($capture && $apiResponseStatus == 'pending') {
             $stateMagento->setState('processing')->setStatus('processing');
         }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/MOD-610
| **What?**         | Set order as processing when API's response is paid.
| **Why?**          | Set Magento's order as paid.
| **How?**          | Add missing condition
