### PR TITLE
Set order as pending when API's response is pending

### DIFF
--- a/Gateway/Transaction/CreditCard/ResourceGateway/Create/Response/GeneralHandler.php
+++ b/Gateway/Transaction/CreditCard/ResourceGateway/Create/Response/GeneralHandler.php
@@ -120,15 +120,11 @@ class GeneralHandler extends AbstractHandler implements HandlerInterface
 
         $apiResponseStatus = $response->status;
 
-        if (!$capture && $apiResponseStatus == 'pending') {
+        if ($apiResponseStatus == 'pending') {
             $stateMagento->setState('pending_payment')->setStatus('pending_payment');
         }
 
         if ($capture && $apiResponseStatus == 'paid') {
-            $stateMagento->setState('processing')->setStatus('processing');
-        }
-
-        if ($capture && $apiResponseStatus == 'pending') {
             $stateMagento->setState('processing')->setStatus('processing');
         }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/MOD-610
| **What?**         | Set order as pending when API's response is pending.
| **Why?**          | Set Magento's order as pending payment.
| **How?**          | Fix missing condition
