### PR TITLE
changed return type to mixed fixing swagger doc breaks

### DIFF
--- a/Api/InstallmentsManagementInterface.php
+++ b/Api/InstallmentsManagementInterface.php
@@ -15,7 +15,7 @@ namespace MundiPagg\MundiPagg\Api;
 interface InstallmentsManagementInterface
 {
     /**
-     * @return array
+     * @return mixed[]
      */
     public function getInstallments();
 }

--- a/Api/MaintenanceInterface.php
+++ b/Api/MaintenanceInterface.php
@@ -6,7 +6,7 @@ interface MaintenanceInterface
 {
     /**
      * @param mixed $params
-     * @return array
+     * @return mixed[]
      */
     public function index($params);
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://github.com/mundipagg/magento2/issues/137
| **What?**         | Changed the interface method doc.
| **Why?**          | This cause errors on swagger API default Magento doc
| **How?**          | Changed the interface doc from array (Magento unsupported) to mixed[] for swagger API doc.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### :package: Attachments (if appropriate)

After changed array to mixed[] it's possible to get all the API endpoints docs (collapsed on print)

![Screenshot at Oct 10 17-12-41](https://user-images.githubusercontent.com/405469/66603118-d518ed80-eb81-11e9-8018-e90a13cf8f6a.png)


And access the swagger docs:

![Screenshot at Oct 10 17-19-00](https://user-images.githubusercontent.com/405469/66603215-13161180-eb82-11e9-9d3d-78c3d9e4423e.png)


#### :speech_balloon: Important guidelines

* Add pull request labels.
* Check base branch.
* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
