### PR TITLE
Fix order history with failed message

### DIFF
--- a/Gateway/Transaction/Base/Command/InitializeCommand.php
+++ b/Gateway/Transaction/Base/Command/InitializeCommand.php
@@ -130,12 +130,14 @@ class InitializeCommand implements CommandInterface
             return $orderDecorator;
         } catch (\Exception $e) {
 
-            $quote->setCustomerNote('mundipagg-failed');
+            $quote->setCustomerNote('');
             $quote->save();
 
+            $message = "Order failed, changing status quote to failed. \n";
+            $message .= "Error message: " . $e->getMessage();
             $log->orderInfo(
                 $orderDecorator->getCode(),
-                "Order failed, changing status quote to failed."
+                $message
             );
 
             throw new M2WebApiException(


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **What?**         | Fix order history with failed message
| **Why?**          | To not save failed message on history when throw an checkout error