### PR TITLE
Fix bug document vatNumber

### DIFF
--- a/view/frontend/web/js/view/payment/default.js
+++ b/view/frontend/web/js/view/payment/default.js
@@ -77,6 +77,10 @@ define(
 
                 var baseUrl = platFormConfig.payment.ccform.base_url;
 
+                if (quote.billingAddress().vatId == "") {
+                    quote.billingAddress().vatId = platFormConfig.customerData.taxvat
+                }
+
                 platFormConfig.base_url = baseUrl;
                 platFormConfig.moduleUrls.installments =
                     baseUrl + installmentsUrl;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/MOD-917
| **What?**         | When an customer create a new Address and not fill VatNumber, an error occurred was a document error at checkout
