### PR TITLE
Disable payments methods(Mundipagg) when the module is disabled

### DIFF
--- a/Observer/PaymentMethodAvailable.php
+++ b/Observer/PaymentMethodAvailable.php
@@ -161,7 +161,7 @@ class PaymentMethodAvailable implements ObserverInterface
         }
 
         if ($this->mundipaggConfig->getVoucherConfig()->isEnabled()) {
-            $paymentMethods[] = "mundipagg_two_creditcard";
+            $paymentMethods[] = "mundipagg_voucher";
         }
 
         if ($this->mundipaggConfig->getDebitConfig()->isEnabled()) {

--- a/Observer/PaymentMethodAvailable.php
+++ b/Observer/PaymentMethodAvailable.php
@@ -114,27 +114,27 @@ class PaymentMethodAvailable implements ObserverInterface
             return $mundipaggPaymentsMethods;
         }
 
-        $flip = array_flip($mundipaggPaymentsMethods);
+        $mundipaggPaymentsMethodsFlip = array_flip($mundipaggPaymentsMethods);
 
-        unset($flip["mundipagg_billet_creditcard"]);
-        unset($flip["mundipagg_two_creditcard"]);
-        unset($flip["mundipagg_voucher"]);
-        unset($flip["mundipagg_debit"]);
-
+        $methodsAvailable = [];
         foreach ($recurrenceProducts as $recurrenceProduct) {
 
-            if (!$recurrenceProduct->getCreditCard()) {
-                unset($flip["mundipagg_creditcard"]);
+            if (
+                $recurrenceProduct->getCreditCard() &&
+                in_array('mundipagg_creditcard', $mundipaggPaymentsMethodsFlip)
+            ) {
+                $methodsAvailable[] = 'mundipagg_creditcard';
             }
 
-            if (!$recurrenceProduct->getBoleto()) {
-                unset($flip["mundipagg_billet"]);
+            if (
+                $recurrenceProduct->getBoleto() &&
+                in_array('mundipagg_billet', $mundipaggPaymentsMethodsFlip)
+            ) {
+                $methodsAvailable[] = 'mundipagg_billet';
             }
         }
 
-        $mundipaggPaymentsMethods = array_flip($flip);
-
-        return $mundipaggPaymentsMethods;
+        return $methodsAvailable;
     }
 
     /**


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/MOD-1031
| **What?**         | When mundipagg module is disabled the payments methods yet stay available to use on checkout.
| **Why?**          | This was necessary because the module was disabled. The norm was that mundipagg payment methods would not show as an option.
| **How?**          | Before displaying the payment methods, check if the mundipagg module is enabled.