### PR TITLE
Invalid TaxVat at checkout in recent magento versions

### DIFF
--- a/Concrete/Magento2PlatformOrderDecorator.php
+++ b/Concrete/Magento2PlatformOrderDecorator.php
@@ -51,6 +51,7 @@ use Magento\Sales\Model\Order\Email\Sender\OrderCommentSender;
 use Magento\Sales\Model\ResourceModel\Order\Status\Collection;
 use Mundipagg\Core\Kernel\Aggregates\Transaction;
 use Mundipagg\Core\Kernel\ValueObjects\TransactionType;
+use Magento\Quote\Model\Quote;
 
 class Magento2PlatformOrderDecorator extends AbstractPlatformOrderDecorator
 {
@@ -471,7 +472,11 @@ class Magento2PlatformOrderDecorator extends AbstractPlatformOrderDecorator
         return $this->$method($quote);
     }
 
-
+    /**
+     * @param Quote $quote
+     * @return Customer
+     * @throws \Exception
+     */
     private function getRegisteredCustomer($quote)
     {
         $quoteCustomer = $quote->getCustomer();
@@ -523,7 +528,7 @@ class Magento2PlatformOrderDecorator extends AbstractPlatformOrderDecorator
         $cleanDocument = preg_replace(
             '/\D/',
             '',
-            $quote->getCustomerTaxvat()
+            $quote->getCustomer()->getTaxVat()
         );
 
         if (empty($cleanDocument)) {
@@ -549,14 +554,18 @@ class Magento2PlatformOrderDecorator extends AbstractPlatformOrderDecorator
         $customer->setAddress($address);
 
         return $customer;
-
     }
 
+    /**
+     * @param Quote $quote
+     * @return Customer
+     * @throws \Exception
+     */
     private function getGuestCustomer($quote)
     {
         $guestAddress = $quote->getBillingAddress();
 
-        $customer = new Customer;
+        $customer = new Customer();
 
         $customer->setName($guestAddress->getName());
         $customer->setEmail($guestAddress->getEmail());


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/CONECT-1117
| **What?**         | Invalid CPF at checkout in recent Magento versions
| **Why?**          | When the user added the subsequent TaxVat to their registration, the checkout could not detect this change and launched an invalid TaxVat error(Only in the latest versions of Magento)
| **How?**          | In actually the Magento changed the way how get the TaxVat(CPF)