### PR TITLE
FIX coupon code JS callback compatibility

### DIFF
--- a/view/frontend/web/js/action/cancel-coupon.js
+++ b/view/frontend/web/js/action/cancel-coupon.js
@@ -37,7 +37,26 @@ define([
 ) {
     'use strict';
 
-    return function (isApplied) {
+    var successCallbacks = [],
+        action,
+        callSuccessCallbacks;
+
+    /**
+     * Execute callbacks when a coupon is successfully canceled.
+     */
+    callSuccessCallbacks = function () {
+        successCallbacks.forEach(function (callback) {
+            callback();
+        });
+    };
+
+    /**
+     * Cancel applied coupon.
+     *
+     * @param {Boolean} isApplied
+     * @returns {Deferred}
+     */
+    action = function (isApplied) {
         var quoteId = quote.getQuoteId(),
             url = urlManager.getCancelCouponUrl(quoteId),
             message = $t('Your coupon was successfully removed.');
@@ -108,4 +127,16 @@ define([
             errorProcessor.process(response, messageContainer);
         });
     };
+    
+    
+    /**
+     * Callback for when the cancel-coupon process is finished.
+     *
+     * @param {Function} callback
+     */
+    action.registerSuccessCallback = function (callback) {
+        successCallbacks.push(callback);
+    };
+
+    return action;
 });

--- a/view/frontend/web/js/action/set-coupon-code.js
+++ b/view/frontend/web/js/action/set-coupon-code.js
@@ -41,7 +41,19 @@ define([
 ) {
     'use strict';
 
-    return function (couponCode, isApplied) {
+    var dataModifiers = [],
+        successCallbacks = [],
+        failCallbacks = [],
+        action;
+
+    /**
+     * Apply provided coupon.
+     *
+     * @param {String} couponCode
+     * @param {Boolean}isApplied
+     * @returns {Deferred}
+     */
+    action = function (couponCode, isApplied) {
         var quoteId = quote.getQuoteId(),
             url = urlManager.getApplyCouponUrl(couponCode, quoteId),
             message = $t('Your coupon was successfully applied.');
@@ -115,4 +127,33 @@ define([
             errorProcessor.process(response, messageContainer);
         });
     };
+
+    /**
+     * Modifying data to be sent.
+     *
+     * @param {Function} modifier
+     */
+    action.registerDataModifier = function (modifier) {
+        dataModifiers.push(modifier);
+    };
+
+    /**
+     * When successfully added a coupon.
+     *
+     * @param {Function} callback
+     */
+    action.registerSuccessCallback = function (callback) {
+        successCallbacks.push(callback);
+    };
+
+    /**
+     * When failed to add a coupon.
+     *
+     * @param {Function} callback
+     */
+    action.registerFailCallback = function (callback) {
+        failCallbacks.push(callback);
+    };
+
+    return action;
 });


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **What?**         | Added core callback functions to coupon code JS files
| **Why?**          | In order to add coupon callback functionality 
| **How?**          | I added the same function that exists in magento/module-sales-rule 

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### :speech_balloon: Important guidelines
I added this because my module use registerSuccessCallback from core's magento/module-sales-rule and with Mundipagg it doesn't work, adding the missing methods, both now are working.
