### PR TITLE
fixes the problem for creating orders by the multiple store administr…

### DIFF
--- a/Concrete/Magento2PlatformOrderDecorator.php
+++ b/Concrete/Magento2PlatformOrderDecorator.php
@@ -555,9 +555,7 @@ class Magento2PlatformOrderDecorator extends AbstractPlatformOrderDecorator
     {
         if ($this->quote === null) {
             $quoteId = $this->platformOrder->getQuoteId();
-
             $objectManager = ObjectManager::getInstance();
-            $quoteFactory = $objectManager->get(QuoteFactory::class);
             $this->quote = $objectManager->create('Magento\Quote\Model\Quote')->loadByIdWithoutStore($quoteId);
         }
 


### PR DESCRIPTION
Quando existem múltiplas lojas no Magento ele não consegue criar pedido para a lojas que não seja a default, isso quando o produto está segmentado por loja.
A correção baseia-se em ler novamente a quote gerada no admin, para que ele possa finalizar o pedido para qualquer loja.
