### PR TITLE
Gets default store view code correctly

### DIFF
--- a/Concrete/Magento2CoreSetup.php
+++ b/Concrete/Magento2CoreSetup.php
@@ -479,6 +479,15 @@ final class Magento2CoreSetup extends AbstractModuleCoreSetup
         return $priceHelper->currency($price, true, false);
     }
 
+    public static function getDefaultStoreViewCode()
+    {
+        $objectManager = ObjectManager::getInstance();
+        $storeInterfaceName = '\Magento\Store\Model\StoreManagerInterface';
+        $storeManager = $objectManager->get($storeInterfaceName);
+
+        return $storeManager->getDefaultStoreView()->getCode();
+    }
+
     public static function getCurrentStoreId()
     {
         $objectManager = ObjectManager::getInstance();

--- a/Helper/Adminhtml/CheckoutHelper.php
+++ b/Helper/Adminhtml/CheckoutHelper.php
@@ -79,7 +79,8 @@ class CheckoutHelper extends AbstractHelper
     }
     public function getInstallmentsUrl($baseUrl)
     {
-        return $baseUrl . "rest/default/V1/mundipagg/installments/brandbyamount";
+        $defaultStoreViewCode = Magento2CoreSetup::getDefaultStoreViewCode();
+        return $baseUrl . "rest/{$defaultStoreViewCode}/V1/mundipagg/installments/brandbyamount";
     }
 
     public function formatGrandTotal($granTotal)


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**           | https://mundipagg.atlassian.net/browse/PAOP-120
| **What?**         | Gets the correct store code before building installments url.
| **Why?**          | To fix a bug when creating a order from admin if the user changes the code of the default store.
| **How?**          | Getting the store's code saved in magento side instead of letting it hardcoded.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### :package: Attachments (if appropriate)
Add additional informations like screenshots, issue link, etc

#### :speech_balloon: Important guidelines

* Add pull request labels.
* Check base branch.
* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
