### PR TITLE
Fixes error if curl return is not a json string

### DIFF
--- a/Factories/BulkSingleResponseFactory.php
+++ b/Factories/BulkSingleResponseFactory.php
@@ -9,9 +9,15 @@ class BulkSingleResponseFactory
 {
     public function createFromCurlResponse(Curl $curlResponse): BulkSingleResponse
     {
+        $body = json_decode($curlResponse->getBody(), true);
+
+        if (!is_array($body)) {
+            $body = ['message' => $body];
+        }
+
         $bulkSingleResponse = new BulkSingleResponse;
         $bulkSingleResponse->setStatus($curlResponse->getStatus());
-        $bulkSingleResponse->setBody(json_decode($curlResponse->getBody(), true));
+        $bulkSingleResponse->setBody($body);
         return $bulkSingleResponse;
     }
 

--- a/Model/Api/Bulk.php
+++ b/Model/Api/Bulk.php
@@ -62,6 +62,8 @@ class Bulk implements BulkApiInterface
             $this->curl->addHeader("Authorization", "Bearer {$accessToken}");
         }
 
+        $this->curl->addHeader("Content-Type", "application/json");
+
         foreach ($bodyParams['requests'] as $key => $request) {
             $validationInfo = $this->validateSingleRequestParams($key, $request);
 
@@ -87,6 +89,14 @@ class Bulk implements BulkApiInterface
         if (!isset($bodyParams['requests'])) {
             throw new MagentoException(
                 __("Requests parameter is required."),
+                0,
+                self::HTTP_BAD_REQUEST
+            );
+        }
+
+        if (empty($bodyParams['requests'])) {
+            throw new MagentoException(
+                __("Requests parameter can not be empty."),
                 0,
                 self::HTTP_BAD_REQUEST
             );
@@ -136,7 +146,7 @@ class Bulk implements BulkApiInterface
     {
         $method = $request['method'];
         $apiUrl = $this->getApiBaseUrl() . $request['path'];
-        $params = $request['params'];
+        $params = json_encode($request['params']);
 
         try {
             $this->curl->$method($apiUrl, $params);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/PAOP-130
| **What?**         | Fixes error if curl return is not a json string and adds application/json header.
| **Why?**          | Because a 500 error was generated when curl returned a string.
