### PR TITLE
:bug: added csp_whitelist.xml to Content Security Policy for Mundipag…

### DIFF
--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<csp_whitelist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Csp:etc/csp_whitelist.xsd">
+    <policies>
+        <policy id="script-src">
+            <values>
+                <value id="mundipagg" type="host">*.mundipagg.com</value>
+            </values>
+        </policy>
+        <policy id="connect-src">
+            <values>
+                <value id="mundipagg" type="host">*.mundipagg.com</value>
+            </values>
+        </policy>
+        <policy id="img-src">
+            <values>
+                <value id="mundipagg" type="host">*.mundipagg.com</value>
+            </values>
+        </policy>
+    </policies>
+</csp_whitelist>


### PR DESCRIPTION
…g token and pix image

| Questions     | Answers
| ------------- | -------------------------------------------------------
| **What?**         | Magento needs csp file to allow external sources.
| **Why?**          | Without it, it's not possible to verify credit card token or to see pix image when CSP is enabled?
| **How?**          | Added a standard file to add a whitelist of domains (https://devdocs.magento.com/guides/v2.4/extension-dev-guide/security/content-security-policies.html)

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->


